### PR TITLE
Support for new Gosu::Image arguments, allow `retro: true` to be set

### DIFF
--- a/gosu_tiled.gemspec
+++ b/gosu_tiled.gemspec
@@ -21,8 +21,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'gosu'
   spec.add_dependency 'json'
 
-  spec.add_development_dependency 'bundler', '~> 1.6'
+  spec.add_development_dependency 'bundler', '~> 2.1'
   spec.add_development_dependency 'rake'
-  spec.add_development_dependency 'rspec', '~> 3.0.0'
+  spec.add_development_dependency 'rspec', '~> 3.9.0'
   spec.add_development_dependency 'guard-rspec'
 end

--- a/gosu_tiled.gemspec
+++ b/gosu_tiled.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'gosu'
+  spec.add_dependency 'gosu', '~> 0.15.1'
   spec.add_dependency 'json'
 
   spec.add_development_dependency 'bundler', '~> 2.1'

--- a/lib/gosu_tiled.rb
+++ b/lib/gosu_tiled.rb
@@ -9,8 +9,8 @@ require 'gosu_tiled/map'
 
 module Gosu
   module Tiled
-    def self.load_json(window, json)
-      Map.new(window, JSON.load(File.open(json)), File.dirname(json))
+    def self.load_json(window, json, options = {})
+      Map.new(window, JSON.load(File.open(json)), File.dirname(json), options)
     end
   end
 end

--- a/lib/gosu_tiled/map.rb
+++ b/lib/gosu_tiled/map.rb
@@ -3,13 +3,13 @@ module Gosu
     class Map
       attr_reader :tilesets, :layers, :width, :height
 
-      def initialize(window, data, data_dir)
+      def initialize(window, data, data_dir, options = {})
         @window = window
         @data = data
         @data_dir = data_dir
         @width = data['width'] * data['tilewidth']
         @height = data['height'] * data['tileheight']
-        @tilesets = Tilesets.new(window, data['tilesets'], data_dir)
+        @tilesets = Tilesets.new(data['tilesets'], data_dir, options)
         @layers = Layers.new(window,
                              data['layers'],
                              width: @width,

--- a/lib/gosu_tiled/tilesets.rb
+++ b/lib/gosu_tiled/tilesets.rb
@@ -1,14 +1,14 @@
 module Gosu
   module Tiled
     class Tilesets
-      def initialize(window, data, data_dir)
+      def initialize(data, data_dir, retro: false, tileable: true)
         @root_dir = data_dir
-        @window = window
         @data = data
         @tilesets = {}
         @data.each do |t|
           tileset = Gosu::Image.load_tiles(
-            @window, File.join(data_dir, t['image']), t['tilewidth'], t['tileheight'], true)
+            File.join(data_dir, t['image']), t['tilewidth'], t['tileheight'], retro: retro, tileable: tileable
+          )
           @tilesets[t['firstgid']] = {
             'data' => t,
             'tiles' => tileset

--- a/spec/gosu_tiled/layer_spec.rb
+++ b/spec/gosu_tiled/layer_spec.rb
@@ -1,14 +1,13 @@
 require 'spec_helper'
 
 RSpec.describe Gosu::Tiled::Layer do
-
   let(:files_dir) { File.join(File.dirname(File.dirname(__FILE__)), 'files') }
   let(:target_class) { Gosu::Tiled::Layer }
   let(:map_json) { JSON.load(File.open(File.join(files_dir, 'tiled_map.json'))) }
   let(:game_window) { TestGameWindow.instance }
   let(:options) { { width: 128 * 10, height: 128 * 10, tile_width: 128, tile_height: 128 } }
 
-  subject(:tilesets) { Gosu::Tiled::Tilesets.new(game_window, map_json['tilesets'], files_dir) }
+  subject(:tilesets) { Gosu::Tiled::Tilesets.new(map_json['tilesets'], files_dir) }
   subject(:tile_layer) { target_class.new(game_window, map_json['layers'][1], options) }
   subject(:object_layer) { target_class.new(game_window, map_json['layers'][3], options) }
 

--- a/spec/gosu_tiled/tilesets_spec.rb
+++ b/spec/gosu_tiled/tilesets_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 RSpec.describe Gosu::Tiled::Tilesets do
-
   let(:files_dir) { File.join(File.dirname(File.dirname(__FILE__)), 'files') }
   let(:target_class) { Gosu::Tiled::Tilesets }
   let(:map_json) { JSON.load(File.open(File.join(files_dir, 'tiled_map.json'))) }
@@ -9,11 +8,39 @@ RSpec.describe Gosu::Tiled::Tilesets do
   let(:water_tile) { 65 }
   let(:sand_tile) { 1 }
 
-  subject(:tilesets) { target_class.new(game_window, map_json['tilesets'], files_dir) }
+  subject(:tilesets) { target_class.new(map_json['tilesets'], files_dir) }
 
   describe '#initialize' do
-    it 'initializes with game window and hash' do
+    it 'initializes with hash of tileset data and a path' do
       expect { tilesets }.to_not raise_error
+    end
+
+    describe 'options argument' do
+      subject(:tilesets_with_options) { target_class.new(map_json['tilesets'], files_dir, retro: true, tileable: false) }
+
+      it 'is accepted by initialize' do
+        expect { tilesets_with_options }.to_not raise_error
+      end
+
+      it 'passes retro and tileable options to Gosu::Image.load_tile' do
+        expect(Gosu::Image)
+          .to receive(:load_tiles)
+          .with(anything, anything, anything, retro: true, tileable: false)
+          .exactly(map_json['tilesets'].count)
+          .times
+
+        expect { tilesets_with_options }.to_not raise_error
+      end
+
+      it 'uses default retro and tileable values when not set' do
+        expect(Gosu::Image)
+          .to receive(:load_tiles)
+          .with(anything, anything, anything, retro: false, tileable: true)
+          .exactly(map_json['tilesets'].count)
+          .times
+
+        expect { tilesets }.to_not raise_error
+      end
     end
   end
 
@@ -49,5 +76,4 @@ RSpec.describe Gosu::Tiled::Tilesets do
       expect(tilesets.properties(water_tile)['name']).to eq 'water'
     end
   end
-
 end


### PR DESCRIPTION
Hi 🙋‍♀️. Thanks for working on this gem! This PR does just a smidge of housekeeping:

* Bumps gem version requirements for `gosu`, as well as two dev dependencies `rspec` and `bundler`
* Updates `Gosu::Tiled::Tilesets`'s calls to `Gosu::Image.load_tiles` to use the newer arguments. See https://rubydoc.info/github/gosu/gosu/master/Gosu%2FImage%2Eload_tiles
* Allows `retro` and `tileable` options to be set when calling `Gosu::Tiled.load_json`
* Adds and fixes specs to verify these behaviors
* A few small whitespace tidy-ups from Rubocop. (I didn't commit most of Rubocop's fixes. If you have a `.rubocop.yml` to add to the repo, I'd be happy to do more tidying 👻

Cheers ☕️