### PR TITLE
Add note about embedding tilesets

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Create yourself a game map with [Tiled](http://www.mapeditor.org/):
 
 ![Tiled Map](https://raw.githubusercontent.com/spajus/gosu-tiled/master/examples/screenshots/tiled.png)
 
-Create your TMX, make sure "Tile Layer Format" is set to "CSV", then export it as JSON and use with Gosu like this:
+Create your TMX, make sure "Tile Layer Format" is set to "CSV" and your tilesets are embedded, then export it as JSON and use with Gosu like this:
 
 ```ruby
 require 'gosu'


### PR DESCRIPTION
Since Tiled 0.13 tilesets from `tsx` files are not included as json, but only referenced. To include them, you need to click the `Embed tileset` button (second from the left) on your tileset in Tiled.

![image](https://user-images.githubusercontent.com/1394828/80802256-2b498e80-8baf-11ea-83ca-8d3991c4a993.png)

This should solve issue #3 by adding a very short note in the README. It might be a good idea to add a helpful exception when detecting that a tileset is not embedded. @spajus Let me know if you think that's a good idea.